### PR TITLE
fix: layout preview missing default style

### DIFF
--- a/popup/src/components/LayoutPreview.vue
+++ b/popup/src/components/LayoutPreview.vue
@@ -1,5 +1,5 @@
 <template>
-  <div ref="el" :style="mergedStyle" class="z-[990] bg-no-repeat bg-center touch-none"></div>
+  <div ref="el" :style="mergedStyle"></div>
 </template>
 
 <script setup lang="ts">
@@ -17,7 +17,11 @@ const props = defineProps<{
 const defaultStyle = computed<StyleValue>(() => {
   return {
     backgroundSize: '100% auto',
-    backgroundImage: `url(${props.imageUrl})`
+    backgroundImage: `url(${props.imageUrl})`,
+    zIndex: 990,
+    backgroundRepeat: 'no-repeat',
+    backgroundPosition: 'center',
+    touchAction: 'none'
   }
 })
 


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
#12 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
After merging #13, the layout preview lost its default styles. This occurred because the layout preview component is teleported to the body, which prevents the shadow DOM styles from being applied correctly. To address this, we introduced a dynamic style injection to ensure the layout preview retains its default styles.


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly (for new feature).
